### PR TITLE
Adjust styles for kramdown compatibility

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -30,29 +30,32 @@ spreadsheets of Excel.
 ### Typographic conventions
 
 <div class="typography-box warning">
-
-> :warning: **Warning** - Alerts users to potential pitfalls or things to be cautious of when using your application.
-
+  <span class="icon">⚠️</span>
+  <span class="content">
+    <strong>Warning :</strong> Alerts users to potential pitfalls or things to be cautious of when using your application.
+  </span>
 </div>
 
 <div class="typography-box tip">
-
-> :bulb: **Tip** - Provides users with additional insights or more efficient ways to use your application.
-
+  <span class="icon">💡</span>
+  <span class="content">
+    <strong>Tip :</strong> Provides users with additional insights or more efficient ways to use your application.
+  </span>
 </div>
 
 <div class="typography-box note">
-
-> :information_source: **Note** - Highlights supplementary information that users should be aware of, but isn't necessarily mission-critical.
-
+  <span class="icon">ℹ️</span>
+  <span class="content">
+    <strong>Note :</strong> Highlights supplementary information that users should be aware of, but isn't necessarily mission-critical.
+  </span>
 </div>
 
 <div class="typography-box code">
-
-> :black_nib: **Code** - Indicates commands or programming-related content that can be typed or referred to.
-
+  <span class="icon">🖋</span>
+  <span class="content">
+    <strong>Code :</strong> Indicates commands or programming-related content that can be typed or referred to.
+  </span>
 </div>
-
 
 ### Non-typographic conventions
 For the feature section, each page follows a predictable syntax and style.
@@ -62,6 +65,8 @@ Proceed to explain ... [TODO]
 
 ## Table of Contents
 
+* TOC 
+{:toc}
 
 ## Quick start
 
@@ -94,16 +99,17 @@ Proceed to explain ... [TODO]
     - For example if you have placed the jar file in the Documents folder, type `cd Documents` and press Enter
 
 <div class="typography-box warning">
-
-> :warning: **Warning:** Do not move or delete the `data` folder as it contains the data of your applications.
-
+  <span class="icon">⚠️</span>
+  <span class="content">
+    <strong>Warning :</strong> Do not move or delete the `data` folder as it contains the data of your applications.
+  </span>
 </div>
-
 
 You should notice the GUI of the application pop up.
 1. Learn more about navigating the GUI [here]().
 2. For new users, learn to use LinkMeIn [here]().
 3. For advanced users, view all feature details [here]().
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## Current Features ##

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -6,19 +6,26 @@
   "minima/skins/{{ site.minima.skin | default: 'classic' }}",
   "minima/initialize";
 
-/* Typography Boxes */
+/* General Typography Box Styling */
 .typography-box {
   border: 1px solid #d3d3d3;
   padding: 10px;
   margin-bottom: 20px;
   border-radius: 5px;
+  display: flex; /* To layout icon and text side by side */
+  align-items: start; /* Align items to the top */
 }
 
-.typography-box > blockquote {
-  border-left: none;
-  padding-left: 15px;
+.typography-box > .icon {
+  margin-right: 10px; /* Space between icon and text */
+  font-size: 24px; /* Adjust icon size if necessary */
 }
 
+.typography-box > .content {
+  flex: 1; /* Allows content to take the remaining width */
+}
+
+/* Specific Styles for each Typography Box Type */
 .typography-box.warning {
   border-color: red;
   background-color: #ffe6e6;
@@ -29,6 +36,15 @@
   background-color: #ffffe0;
 }
 
+.typography-box.note {
+  border-color: #a8d1ff;
+  background-color: #e5f3ff;
+}
+
+.typography-box.code {
+  border-color: #b0b0b0;
+  background-color: #f5f5f5;
+}
 .typography-box.note {
   border-color: #c8e1ff;
   background-color: #e8f4ff;


### PR DESCRIPTION
## Summary

Edit User Guide style for Kramdown compatibility.  

## Description

The user guide was originally styled with
GFM syntax, which rendered perfectly in GFM.
However, GitHub Pages deployments utilize
kramdown, leading to discrepancies in the
rendering.

Let's modify the Table of Contents and
introduction box styles to ensure compatibility
with kramdown. This change will make certain
that our guide is displayed consistently and
correctly on GitHub Pages.

Adapting to kramdown ensures the documentation
remains professional and accessible to all
users, irrespective of the markdown processor
used in the backend.
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [ ] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed