### PR TITLE
Fix deadline output

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -128,8 +128,11 @@ public class ParserUtil {
         if (trimmedDeadline.isEmpty()) {
             throw new ParseException(Deadline.MESSAGE_CONSTRAINTS_NON_EMPTY);
         }
+        if (!Deadline.isValidFormat(trimmedDeadline)) {
+            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS_WRONG_FORMAT);
+        }
         if (!Deadline.isValidDeadline(trimmedDeadline)) {
-            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS_VALID_REGEX);
+            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS_INVALID_DEADLINE);
         }
         return new Deadline(trimmedDeadline);
     }

--- a/src/main/java/seedu/address/model/company/Deadline.java
+++ b/src/main/java/seedu/address/model/company/Deadline.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents a Company's deadline in the address book.
@@ -15,12 +16,16 @@ public class Deadline implements Comparable<Deadline> {
 
     public static final String MESSAGE_CONSTRAINTS_NON_EMPTY =
             "Oops! Deadline should not be blank! Please try again with a valid deadline of format DD-MM-YYYY.";
-    public static final String MESSAGE_CONSTRAINTS_VALID_REGEX =
+    public static final String MESSAGE_CONSTRAINTS_INVALID_DEADLINE =
             "Oops! You have entered an invalid deadline! Please try again with the deadline format DD-MM-YYYY.";
-    public static final String VALIDATION_REGEX = "^(0[1-9]|[12][0-9]|3[01])-(0[1-9]|1[0-2])-(19[0-9]{2}|2[0-9]{3})$";
-    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
-    public final LocalDate value;
 
+    public static final String MESSAGE_CONSTRAINTS_WRONG_FORMAT =
+            "Oops! You have entered an incorrect format for the deadline! Please use the format DD-MM-YYYY.";
+
+    public static final String FORMAT_REGEX = "^\\d{2}-\\d{2}-\\d{4}$";
+    public static final DateTimeFormatter FORMATTER =
+            DateTimeFormatter.ofPattern("dd-MM-uuuu").withResolverStyle(ResolverStyle.STRICT);
+    public final LocalDate value;
 
     /**
      * Constructs a {@code Deadline}.
@@ -30,15 +35,23 @@ public class Deadline implements Comparable<Deadline> {
     public Deadline(String deadline) {
         requireNonNull(deadline);
         checkArgument(!deadline.isBlank(), MESSAGE_CONSTRAINTS_NON_EMPTY);
-        checkArgument(isValidDeadline(deadline), MESSAGE_CONSTRAINTS_VALID_REGEX);
+        checkArgument(isValidFormat(deadline), MESSAGE_CONSTRAINTS_WRONG_FORMAT);
+        checkArgument(isValidDeadline(deadline), MESSAGE_CONSTRAINTS_INVALID_DEADLINE);
         this.value = LocalDate.parse(deadline, FORMATTER);
+    }
+
+    /**
+     * Returns true if the given string follows the correct format.
+     */
+    public static boolean isValidFormat(String test) {
+        return test.matches(FORMAT_REGEX);
     }
 
     /**
      * Returns true if a given string is a valid deadline.
      */
     public static boolean isValidDeadline(String test) {
-        if (!test.matches(VALIDATION_REGEX)) {
+        if (!isValidFormat(test)) {
             return false;
         }
 
@@ -49,7 +62,6 @@ public class Deadline implements Comparable<Deadline> {
             return false;
         }
     }
-
 
     @Override
     public String toString() {
@@ -84,4 +96,3 @@ public class Deadline implements Comparable<Deadline> {
         return this.value.compareTo(other.value);
     }
 }
-

--- a/src/main/java/seedu/address/storage/JsonAdaptedCompany.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedCompany.java
@@ -111,7 +111,7 @@ class JsonAdaptedCompany {
                     Deadline.class.getSimpleName()));
         }
         if (!Deadline.isValidDeadline(deadline)) {
-            throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS_VALID_REGEX);
+            throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS_INVALID_DEADLINE);
         }
         final Deadline modelDeadline = new Deadline(deadline);
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -260,7 +260,7 @@ public class AddCommandParserTest {
         // invalid deadline
         assertParseFailure(parser, NAME_DESC_TIKTOK + PHONE_DESC_TIKTOK + EMAIL_DESC_TIKTOK
                 + ROLE_DESC_TIKTOK + INVALID_DEADLINE_DESC + STATUS_DESC_TIKTOK + RECRUITER_NAME_DESC_TIKTOK
-                + PRIORITY_DESC_TIKTOK, Deadline.MESSAGE_CONSTRAINTS_VALID_REGEX);
+                + PRIORITY_DESC_TIKTOK, Deadline.MESSAGE_CONSTRAINTS_WRONG_FORMAT);
 
         // invalid status
         assertParseFailure(parser, NAME_DESC_TIKTOK + PHONE_DESC_TIKTOK + EMAIL_DESC_TIKTOK


### PR DESCRIPTION
Display different message to user based on
if they typed incorrect format or invalid
deadline.

Enabled strict mode for LocalDate to no
longer allow invalid deadlines.