### PR TITLE
Fix error message bug for Add and Filter Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -24,7 +24,7 @@ public class AddCommand extends Command {
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE =
-            "Parameters: "
+            "Format: " + COMMAND_WORD + " "
             + PREFIX_COMPANY_NAME + "COMPANY_NAME "
             + PREFIX_ROLE + "ROLE "
             + PREFIX_STATUS + "STATUS "

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -17,7 +17,7 @@ public class FilterCommand extends Command {
     public static final String COMMAND_WORD = "filter";
 
     public static final String MESSAGE_USAGE =
-            "Parameter: " + PREFIX_STATUS + "STATUS. Valid statuses are: PA, PI, PO, A, R\n"
+            "Format: " + COMMAND_WORD + " " + PREFIX_STATUS + "STATUS. Valid statuses are: PA, PI, PO, A, R\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_STATUS + "PA";
 
     public static final String MESSAGE_SUCCESS = "Filtered company list by application status: %1$s";


### PR DESCRIPTION
Update invalid command format error message for Add and Filter Command.
Previously, error message states to refer to command format below, but error message only shows the command parameters instead.
Now, error message is fixed to show the correct format instead. 